### PR TITLE
Add ability to set an 'annealLength' for generating the initial samples

### DIFF
--- a/src/app/serverwrapper.cpp
+++ b/src/app/serverwrapper.cpp
@@ -14,9 +14,41 @@ namespace stateline
     delegator.start();
   }
 
+  std::pair<Eigen::VectorXd,double> generateInitialSample(const StatelineSettings& s,
+                                                          comms::Requester& requester)
+  {
+    uint n = s.annealLength;
+
+    std::vector<Eigen::VectorXd> sampleVec(n);
+
+    // Send n random samples to workers to be evaluated
+    for (uint i=0; i<n; ++i)
+    {
+      sampleVec[i] = Eigen::VectorXd::Random(s.ndims);
+      requester.submit(i, s.jobTypes, sampleVec[i]);
+    }
+
+    // Retrieve all results and select sample with lowest energy
+    uint minEnergyIndex = 0;
+    double minEnergy = std::numeric_limits<double>::max();
+
+    for (uint i=0; i<n; ++i)
+    {
+      auto result = requester.retrieve();
+      uint id = result.first;
+      double energy = std::accumulate(std::begin(result.second), std::end(result.second), 0.0);
+      if (energy < minEnergy)
+      {
+        minEnergyIndex = id;
+        minEnergy = energy;
+      }
+    }
+
+    return {sampleVec[minEnergyIndex], minEnergy};
+  }
+
   void runSampler(const StatelineSettings& s, zmq::context_t& context, bool& running)
   {
-
     mcmc::SlidingWindowSigmaAdapter sigmaAdapter(s.nstacks, s.nchains, s.ndims, s.sigmaSettings);
     mcmc::SlidingWindowBetaAdapter betaAdapter(s.nstacks, s.nchains, s.betaSettings);
     mcmc::GaussianCovProposal proposal(s.nstacks, s.nchains, s.ndims);
@@ -26,20 +58,18 @@ namespace stateline
     // Create a chain array.
     mcmc::ChainArray chains(s.nstacks, s.nchains, s.chainSettings);
 
+    LOG(INFO) << "Initialising chains using annealLength = " << s.annealLength;
 
     for (uint i = 0; i < s.nstacks * s.nchains; i++)
     {
-      // Generate a random initial sample
-      Eigen::VectorXd sample = Eigen::VectorXd::Random(s.ndims);
-
-      // We now use the worker interface to evaluate this initial sample
-      requester.submit(i, s.jobTypes, sample);
-
-      auto result = requester.retrieve();
-      double energy = std::accumulate(std::begin(result.second), std::end(result.second), 0.0);
+      // Generate the initial sample/energy for this chain
+      Eigen::VectorXd sample;
+      double energy;
+      std::tie(sample,energy) = generateInitialSample(s,requester);
 
       // Initialise this chain with the evaluated sample
       chains.initialise(i, sample, energy, sigmaAdapter.sigmas()[i], betaAdapter.betas()[i]);
+      LOG(INFO) << "Initialising chain " << i << " with energy: " << energy;
     }
 
     // A sampler just takes the worker interface, chain array, proposal function,

--- a/src/app/serverwrapper.hpp
+++ b/src/app/serverwrapper.hpp
@@ -24,6 +24,7 @@ namespace stateline
       uint ndims;
       uint nstacks;
       uint nchains;
+      uint annealLength;
       uint nsecs;
       uint swapInterval;
       int msLoggingRefresh;
@@ -38,6 +39,7 @@ namespace stateline
         s.ndims = j["dimensionality"];
         s.nstacks = j["parallelTempering"]["stacks"];
         s.nchains = j["parallelTempering"]["chains"];
+        s.annealLength = j["annealLength"];
         s.nsecs = j["duration"];
         s.swapInterval = j["parallelTempering"]["swapInterval"];
         s.msLoggingRefresh = 1000;

--- a/src/bin/cpp-demo-config.json
+++ b/src/bin/cpp-demo-config.json
@@ -7,6 +7,7 @@
   "duration": 20,
   "sigma": 1.0,
   "jobTypes": ["job"],
+  "annealLength": 1,
   "sigmaAdaption": {
     "windowSize": 100000,
     "adaptionLength": 100000,


### PR DESCRIPTION
There's no rush to review this. I am just trying to move out from obsidian any functionality that is not specific to geological inversions. Talking with Alistair and Lachlan, they said that this initialisation optimisation could belong in stateline.

The changes allow the server to select the best of n random samples, instead of just 1 random sample, when initialising each chain. Setting the config value to 1 provides the same behaviour as before.