### PR TITLE
Add ProposalBounds setting for defining proposed sample bounds

### DIFF
--- a/src/app/serverwrapper.cpp
+++ b/src/app/serverwrapper.cpp
@@ -19,7 +19,7 @@ namespace stateline
 
     mcmc::SlidingWindowSigmaAdapter sigmaAdapter(s.nstacks, s.nchains, s.ndims, s.sigmaSettings);
     mcmc::SlidingWindowBetaAdapter betaAdapter(s.nstacks, s.nchains, s.betaSettings);
-    mcmc::GaussianCovProposal proposal(s.nstacks, s.nchains, s.ndims);
+    mcmc::GaussianCovProposal proposal(s.nstacks, s.nchains, s.ndims, s.proposalBounds);
     mcmc::CovarianceEstimator covEstimator(s.nstacks, s.nchains, s.ndims);
     comms::Requester requester(context);
 

--- a/src/app/serverwrapper.hpp
+++ b/src/app/serverwrapper.hpp
@@ -15,10 +15,10 @@
 #include <json.hpp>
 #include "../infer/adaptive.hpp"
 #include "../infer/chainarray.hpp"
+#include "../infer/sampler.hpp"
 
 namespace stateline
 {
-  
   struct StatelineSettings
   {
       uint ndims;
@@ -31,6 +31,7 @@ namespace stateline
       mcmc::SlidingWindowBetaSettings betaSettings;
       mcmc::ChainSettings chainSettings;
       std::vector<std::string> jobTypes;
+      mcmc::ProposalBounds proposalBounds;
 
       static StatelineSettings fromJSON(const nlohmann::json& j)
       {
@@ -49,6 +50,9 @@ namespace stateline
         {
           s.jobTypes.push_back(i);
         }
+
+        if (j.count("boundaries"))
+          s.proposalBounds = mcmc::ProposalBounds::fromJSON(j);
         
         return s;
       }

--- a/src/bin/cpp-demo-config.json
+++ b/src/bin/cpp-demo-config.json
@@ -1,8 +1,8 @@
 {
   "dimensionality": 4,
   "boundaries": {
-    "min": [0.1],
-    "max": [1.0]
+    "min": [-10,  0, -10, -10],
+    "max": [ 10, 10,  10,   2]
   },
   "duration": 20,
   "sigma": 1.0,

--- a/src/bin/python-demo-config.json
+++ b/src/bin/python-demo-config.json
@@ -1,8 +1,8 @@
 {
   "dimensionality": 4,
   "boundaries": {
-    "min": [0.1],
-    "max": [1.0]
+    "min": [-10,  0, -10, -10],
+    "max": [ 10, 10,  10,   2]
   },
   "duration": 20,
   "sigma": 1.0,

--- a/src/infer/sampler.cpp
+++ b/src/infer/sampler.cpp
@@ -83,7 +83,7 @@ namespace stateline
       for (uint i = 0; i < n; i++)
         randn(i) = rand_(gen_);
 
-      return sample + sigL_[id] * randn * sigma * sigma;
+      return sample + sigL_[id] * randn * sigma;
     }
 
     Eigen::VectorXd GaussianCovProposal::boundedPropose(uint id, const Eigen::VectorXd& sample, double sigma)

--- a/src/infer/sampler.cpp
+++ b/src/infer/sampler.cpp
@@ -11,7 +11,10 @@
 
 #include "infer/sampler.hpp"
 
+#include <functional>
 #include <iostream>
+
+namespace ph = std::placeholders;
 
 namespace stateline
 {
@@ -53,33 +56,23 @@ namespace stateline
       return result;
     }
 
-    Eigen::VectorXd gaussianProposal(uint id, const Eigen::VectorXd& sample, double sigma)
-    {
-      // Random number generators
-      static std::random_device rd;
-      static std::mt19937 generator(rd());
-      static std::normal_distribution<> rand; // Standard normal
-
-      // Vary each paramater according to a Gaussian distribution
-      Eigen::VectorXd proposal(sample.rows());
-      for (int i = 0; i < proposal.rows(); i++)
-        proposal(i) = sample(i) + rand(generator) * sigma;
-
-      return proposal;
-    }
-
-    Eigen::VectorXd truncatedGaussianProposal(uint id, const Eigen::VectorXd& sample,
-        double sigma,
-        const Eigen::VectorXd& min, const Eigen::VectorXd& max)
-    {
-      return bouncyBounds(gaussianProposal(id, sample, sigma), min, max);
-    }
-
-    GaussianCovProposal::GaussianCovProposal(uint nStacks, uint nChains, uint nDims)
-      : gen_(std::random_device()()), sigL_(nStacks * nChains)
+    GaussianCovProposal::GaussianCovProposal(uint nStacks, uint nChains, uint nDims,
+                                             const ProposalBounds& bounds)
+      : gen_(std::random_device()()), sigL_(nStacks * nChains), bounds_(bounds)
     {
       for (uint i = 0; i < nStacks * nChains; i++)
         update(i, Eigen::MatrixXd::Identity(nDims, nDims)); 
+
+      if ((bounds_.min.rows() == nDims) && (bounds_.max.rows() == nDims))
+      {
+        LOG(INFO) << "Using a bounded Gaussian proposal function";
+        proposeFn_ = std::bind(&GaussianCovProposal::boundedPropose, this, ph::_1, ph::_2, ph::_3);
+      }
+      else
+      {
+        LOG(INFO) << "Using a Gaussian proposal function";
+        proposeFn_ = std::bind(&GaussianCovProposal::propose, this, ph::_1, ph::_2, ph::_3);
+      }
     }
 
     Eigen::VectorXd GaussianCovProposal::propose(uint id, const Eigen::VectorXd &sample, double sigma)
@@ -93,9 +86,14 @@ namespace stateline
       return sample + sigL_[id] * randn * sigma * sigma;
     }
 
+    Eigen::VectorXd GaussianCovProposal::boundedPropose(uint id, const Eigen::VectorXd& sample, double sigma)
+    {
+      return bouncyBounds(propose(id, sample, sigma), bounds_.min, bounds_.max);
+    }
+
     Eigen::VectorXd GaussianCovProposal::operator()(uint id, const Eigen::VectorXd &sample, double sigma)
     {
-      return propose(id, sample, sigma);
+      return proposeFn_(id, sample, sigma);
     }
 
     void GaussianCovProposal::update(uint id, const Eigen::MatrixXd &cov)


### PR DESCRIPTION
Changes I've made to get the "bouncyBounds" proposal to work in stateline. I have added bounds to the demo's and the triangle plots look correct.

@AlistaiReid, could you please have a look at this. 

I am applying the `bouncyBounds` function to the `GaussianCovProposal::propose` function, not using the `gaussianProposal` or `truncatedGaussianProposal` functions (which I have deleted to make it easier to see in the diff).

I suspect I am missing something, though, as the these two differ in how they calculate the proposal:

`gaussianProposal`:

    for (int i = 0; i < proposal.rows(); i++)		
      proposal(i) = sample(i) + rand(generator) * sigma;

`GaussianCovProposal::propose` has an extra `sigma` and a `sigL_` matrix which is updated each step:

    proposal = sample + sigL_[id] * randn * sigma * sigma;

