### PR TITLE
Feat/fix chain output

### DIFF
--- a/src/infer/chainarray.cpp
+++ b/src/infer/chainarray.cpp
@@ -191,7 +191,9 @@ namespace stateline
       // Save the swap only on the lower temperature chain
       if (swapped)
       {
-        std::swap(stateh, statel);
+        std::swap(stateh.sample, statel.sample);
+        std::swap(stateh.energy, statel.energy);
+        std::swap(stateh.accepted, statel.accepted);
         statel.swapType = SwapType::Accept;
         setLastState(hId, stateh);
         setLastState(lId, statel);

--- a/src/infer/chainarray.cpp
+++ b/src/infer/chainarray.cpp
@@ -169,7 +169,10 @@ namespace stateline
       }
       else
       {
-        writer_.replaceLast(id / numChains(), state);
+        if (chainIndex(id) == 0)
+        {
+          writer_.replaceLast(id / numChains(), state);
+        }
         lastState_[id] = state;
       }
     }


### PR DESCRIPTION
I noticed sigma and beta values from hotter chains in the output files. It appears they came from 2 separate issues:

1. Chain array writer replacing the last state for chains other than the coldest.
2. Swapping beta and sigma values when swapping chains. I changed this to only swap `sample`, `energy`, and the `accepted` flag. I'm not 100% sure if this is correct, could someone have a look.