### PR TITLE
Travis CI with Docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ services:
   - docker
 
 before_install:
-  - docker build -t NICTA/stateline .
+  - docker build -t nicta/stateline .
   - docker ps -a
 
 script:
-  - docker run NICTA/stateline make test
+  - docker run nicta/stateline make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+
+language: c++
+
+services:
+  - docker
+
+before_install:
+  - docker build -t NICTA/stateline .
+  - docker ps -a
+
+script:
+  - docker run NICTA/stateline make test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 stateline
 =========
+
+[![Build Status](https://travis-ci.org/NICTA/stateline.svg)](https://travis-ci.org/NICTA/stateline)
+
 Stateline is a framework for distributed Markov Chain Monte Carlo (MCMC) sampling written in C++11. It focuses on [parallel tempering](http://en.wikipedia.org/wiki/Parallel_tempering) methods which are highly parallelisable.
 
 System Support


### PR DESCRIPTION
This sets up Travis CI to build the Docker image from the Dockerfile. Currently, Travis CI will report failure as the log from the Docker build exceeds 4MB and immediately aborts. Will need to find a way to suppress some output and decrease verbosity when invoked by Travis CI.